### PR TITLE
Feat: 포인트 사용 기능 개발

### DIFF
--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -1,5 +1,7 @@
 package io.hhplus.tdd;
 
+import io.hhplus.tdd.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,5 +12,11 @@ class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return ResponseEntity.status(500).body(new ErrorResponse("500", "에러가 발생했습니다."));
+    }
+
+    @ExceptionHandler(value = NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse("404", "요청한 리소스를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/io/hhplus/tdd/exception/NotFoundException.java
+++ b/src/main/java/io/hhplus/tdd/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package io.hhplus.tdd.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/io/hhplus/tdd/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/controller/PointController.java
@@ -37,7 +37,7 @@ public class PointController {
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        return pointService.getPointHistories(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/controller/PointController.java
@@ -1,5 +1,8 @@
-package io.hhplus.tdd.point;
+package io.hhplus.tdd.point.controller;
 
+import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.service.PointService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +14,11 @@ import java.util.List;
 public class PointController {
 
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
+    private final PointService pointService;
+
+    public PointController(PointService pointService) {
+        this.pointService = pointService;
+    }
 
     /**
      * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
@@ -19,7 +27,7 @@ public class PointController {
     public UserPoint point(
             @PathVariable long id
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.getUserPoint(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/controller/PointController.java
@@ -59,6 +59,6 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.usePoint(id, amount);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/controller/PointController.java
@@ -48,7 +48,7 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.chargePoint(id, amount);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -1,0 +1,22 @@
+package io.hhplus.tdd.point.service;
+
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.exception.NotFoundException;
+import io.hhplus.tdd.point.UserPoint;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PointService {
+
+    private final UserPointTable userPointTable;
+
+    public PointService(UserPointTable userPointTable) {
+        this.userPointTable = userPointTable;
+    }
+
+    public UserPoint getUserPoint(long userId) {
+        return Optional.ofNullable(userPointTable.selectById(userId))
+            .orElseThrow(() -> new NotFoundException("User not found userid : " + userId));
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -35,7 +35,7 @@ public class PointService {
 
     public UserPoint chargePoint(long userId, long amount) {
         if (amount <= 0) {
-            throw new IllegalArgumentException("The recharge amount must be greater than 0");
+            throw new IllegalArgumentException("amount must be greater than 0");
         }
 
         UserPoint userPoint = Optional.ofNullable(userPointTable.selectById(userId))
@@ -49,5 +49,24 @@ public class PointService {
         return updatedUserPoint;
     }
 
+    public UserPoint usePoint(long userId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be greater than 0");
+        }
+
+        UserPoint userPoint = Optional.ofNullable(userPointTable.selectById(userId))
+            .orElseThrow(() -> new NotFoundException("User not found userid: " + userId));
+
+        if (userPoint.point() < amount) {
+            throw new IllegalArgumentException("Insufficient balance.");
+        }
+
+        long updatedPoint = userPoint.point() - amount;
+        UserPoint updatedUserPoint = userPointTable.insertOrUpdate(userId, updatedPoint);
+
+        pointHistoryTable.insert(userId, amount, TransactionType.USE, System.currentTimeMillis());
+
+        return updatedUserPoint;
+    }
 
 }

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -1,8 +1,11 @@
 package io.hhplus.tdd.point.service;
 
+import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import io.hhplus.tdd.exception.NotFoundException;
+import io.hhplus.tdd.point.PointHistory;
 import io.hhplus.tdd.point.UserPoint;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
@@ -10,13 +13,22 @@ import org.springframework.stereotype.Service;
 public class PointService {
 
     private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
 
-    public PointService(UserPointTable userPointTable) {
+    public PointService(UserPointTable userPointTable, PointHistoryTable pointHistoryTable) {
         this.userPointTable = userPointTable;
+        this.pointHistoryTable = pointHistoryTable;
     }
 
     public UserPoint getUserPoint(long userId) {
         return Optional.ofNullable(userPointTable.selectById(userId))
             .orElseThrow(() -> new NotFoundException("User not found userid : " + userId));
+    }
+
+    public List<PointHistory> getPointHistories(long userId) {
+        if (userPointTable.selectById(userId) == null) {
+            throw new NotFoundException("User not found userid: " + userId);
+        }
+        return pointHistoryTable.selectAllByUserId(userId);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -4,6 +4,7 @@ import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import io.hhplus.tdd.exception.NotFoundException;
 import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.TransactionType;
 import io.hhplus.tdd.point.UserPoint;
 import java.util.List;
 import java.util.Optional;
@@ -31,4 +32,22 @@ public class PointService {
         }
         return pointHistoryTable.selectAllByUserId(userId);
     }
+
+    public UserPoint chargePoint(long userId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("The recharge amount must be greater than 0");
+        }
+
+        UserPoint userPoint = Optional.ofNullable(userPointTable.selectById(userId))
+            .orElseThrow(() -> new NotFoundException("User not found userid: " + userId));
+
+        long updatedPoint = userPoint.point() + amount;
+        UserPoint updatedUserPoint = userPointTable.insertOrUpdate(userId, updatedPoint);
+
+        pointHistoryTable.insert(userId, amount, TransactionType.CHARGE, System.currentTimeMillis());
+
+        return updatedUserPoint;
+    }
+
+
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -1,0 +1,74 @@
+package io.hhplus.tdd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.exception.NotFoundException;
+import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.service.PointService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class PointServiceTest {
+
+    @Mock
+    private UserPointTable userPointTable;
+
+    private PointService pointService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        pointService = new PointService((userPointTable));
+    }
+
+    @AfterEach
+    void afterEach(TestInfo testInfo) {
+        System.out.println("테스트 완료: " + testInfo.getDisplayName());
+    }
+
+    @Test
+    @DisplayName("Test getUserPoint - Success Case")
+    void testGetUserPoint() {
+        // Given
+        long userId = 1L;
+        UserPoint userPoint = new UserPoint(userId, 100, System.currentTimeMillis());
+        when(userPointTable.selectById(userId)).thenReturn(userPoint);
+
+        //When
+        UserPoint result = pointService.getUserPoint(userId);
+
+        //Then
+        assertThat(result).isEqualTo(userPoint);
+    }
+
+    @Test
+    @DisplayName("Test getUserPoint - Not Found Case")
+    void testGetUserPointNotFound() {
+        //Given
+        long userId = -1L;
+        when(userPointTable.selectById(userId)).thenReturn(null);
+
+        //When & Then
+        assertThrows(NotFoundException.class, () -> pointService.getUserPoint(userId));
+    }
+
+    @Test
+    @DisplayName("Test testGetUserPointWithZeroId - Not Found Case")
+    void testGetUserPointWithZeroId() {
+        // Given
+        long userId = 0L;
+        when(userPointTable.selectById(userId)).thenReturn(null);
+
+        // When & Then
+        assertThrows(NotFoundException.class, () -> pointService.getUserPoint(userId));
+    }
+
+}

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -4,10 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import io.hhplus.tdd.exception.NotFoundException;
+import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.TransactionType;
 import io.hhplus.tdd.point.UserPoint;
 import io.hhplus.tdd.point.service.PointService;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,12 +25,15 @@ public class PointServiceTest {
     @Mock
     private UserPointTable userPointTable;
 
+    @Mock
+    private PointHistoryTable pointHistoryTable;
+
     private PointService pointService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        pointService = new PointService((userPointTable));
+        pointService = new PointService(userPointTable, pointHistoryTable);
     }
 
     @AfterEach
@@ -69,6 +76,37 @@ public class PointServiceTest {
 
         // When & Then
         assertThrows(NotFoundException.class, () -> pointService.getUserPoint(userId));
+    }
+
+    @Test
+    @DisplayName("Test getPointHistories - Success Case")
+    void testGetPointHistories() {
+        // Given
+        long userId = 1L;
+        UserPoint userPoint = new UserPoint(userId, 100, System.currentTimeMillis());
+        List<PointHistory> histories = List.of(
+            new PointHistory(1L, userId, 50, TransactionType.CHARGE, System.currentTimeMillis()),
+            new PointHistory(2L, userId, 30, TransactionType.USE, System.currentTimeMillis())
+        );
+        when(userPointTable.selectById(userId)).thenReturn(userPoint);
+        when(pointHistoryTable.selectAllByUserId(userId)).thenReturn(histories);
+
+        // When
+        List<PointHistory> result = pointService.getPointHistories(userId);
+
+        // Then
+        assertThat(result).isEqualTo(histories);
+    }
+
+    @Test
+    @DisplayName("Test getPointHistories - User Not Found Case")
+    void testGetPointHistoriesUserNotFound() {
+        // Given
+        long userId = 1L;
+        when(userPointTable.selectById(userId)).thenReturn(null);
+
+        // When & Then
+        assertThrows(NotFoundException.class, () -> pointService.getPointHistories(userId));
     }
 
 }


### PR DESCRIPTION
fc73fae

PointService에 usePoint 메서드 구현
  - 사용자 ID와 사용할 포인트 금액을 받아 포인트를 차감하는 기능 추가
  - 사용 금액이 0 이하인 경우 IllegalArgumentException 발생
  - 잔액이 부족한 경우 IllegalArgumentException 발생
  - 사용자를 찾지 못할 경우 NotFoundException 발생

PointController에 use 엔드포인트 구현
  - PATCH /point/{id}/use 요청 처리

PointServiceTest에 테스트 케이스 추가
   - testUsePoint (사용 성공)
   - testUsePointInsufficientBalance (잔액 부족)
   - testUsePointInvalidAmount (잘못된 사용 금액)
   - testUsePointUserNotFound (사용자 없음)